### PR TITLE
HC-104: Update ingest lambda to support job type to regex mapping

### DIFF
--- a/aws/data-staged/lambda_function.py
+++ b/aws/data-staged/lambda_function.py
@@ -17,11 +17,14 @@ def __get_job_type_info(data_file, job_types, default_type, default_release,
     Determine the job type.
 
     :param data_file: The data file being ingested.
-    :param job_type: Either a single job type value or a
-    mapping of job types to a regex.
-    :return: If the given job_type is a string, then this will simply get
-    returned. Otherwise, the job_type associated with the given data_file is
-    given.
+    :param job_types: A mapping of job types to a regex.
+    :param default_type: Default job type.
+    :param default_release: Default job release version.
+    :param: default_queue: Default job queue.
+    :return: Function will try to match the given data file to one of 
+    the types specified in the job type mapping. If no mapping exists 
+    or a match could not be found, then it will use the default job
+    type, release, and queue.
     """
     for type in job_types.keys():
         regex = job_types[type]['PATTERN']

--- a/aws/data-staged/lambda_function.py
+++ b/aws/data-staged/lambda_function.py
@@ -78,9 +78,9 @@ def lambda_handler(event, context):
     id = data_file = os.path.basename(ds_url)
     
     # submit mozart jobs to update ES
-    default_job_type = os.environ['DEFAULT_JOB_TYPE'] # e.g. "INGEST_L0A_LR_RAW"
-    default_job_release = os.environ['DEFAULT_JOB_RELEASE'] # e.g. "gman-dev"
-    default_queue = os.environ['DEFAULT_JOB_QUEUE']
+    default_job_type = os.environ['JOB_TYPE'] # e.g. "INGEST_L0A_LR_RAW"
+    default_job_release = os.environ['JOB_RELEASE'] # e.g. "gman-dev"
+    default_queue = os.environ['JOB_QUEUE']
     job_types = {}
     if 'JOB_TYPES' in os.environ:
         job_types = json.loads(os.environ['JOB_TYPES'])

--- a/aws/data-staged/lambda_function.py
+++ b/aws/data-staged/lambda_function.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 
 import os, sys, re, json, requests, boto3
 from utils import submit_job
-import yaml
 
 print ('Loading function')
 
@@ -10,10 +9,6 @@ signal_file_suffix = None
 
 if "SIGNAL_FILE_SUFFIX" in os.environ:
     signal_file_suffix = os.environ['SIGNAL_FILE_SUFFIX']
-
-# have yaml parse regular expressions
-yaml.SafeLoader.add_constructor(u'tag:yaml.org,2002:python/regexp',
-                                lambda l, n: re.compile(l.construct_scalar(n)))
 
 
 def __get_job_type_info(data_file, job_types, default_type, default_release,

--- a/aws/data-staged/lambda_function.py
+++ b/aws/data-staged/lambda_function.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import os, sys, re, json, requests, boto3
 from utils import submit_job
+import yaml
 
 print ('Loading function')
 
@@ -9,6 +10,34 @@ signal_file_suffix = None
 
 if "SIGNAL_FILE_SUFFIX" in os.environ:
     signal_file_suffix = os.environ['SIGNAL_FILE_SUFFIX']
+
+# have yaml parse regular expressions
+yaml.SafeLoader.add_constructor(u'tag:yaml.org,2002:python/regexp',
+                                lambda l, n: re.compile(l.construct_scalar(n)))
+
+
+def __get_job_type_info(data_file, job_types, default_type, default_release,
+                   default_queue):
+    """
+    Determine the job type.
+
+    :param data_file: The data file being ingested.
+    :param job_type: Either a single job type value or a
+    mapping of job types to a regex.
+    :return: If the given job_type is a string, then this will simply get
+    returned. Otherwise, the job_type associated with the given data_file is
+    given.
+    """
+    for type in job_types.keys():
+        regex = job_types[type]['PATTERN']
+        print("Checking if {} matches {}".format(regex, data_file))
+        match = regex.search(data_file)
+        if match:
+            return type, job_types[type]['RELEASE'], job_types[type]['QUEUE']
+    print("Could not match data file '{}' to a given job type: {}".format(
+        data_file, job_types.keys()))
+    return default_type, default_release, default_queue
+
 
 def lambda_handler(event, context):
     '''
@@ -48,9 +77,17 @@ def lambda_handler(event, context):
     # data file
     id = data_file = os.path.basename(ds_url)
     
-    #submit mozart jobs to update ES
-    job_type = os.environ['JOB_TYPE'] # e.g. "INGEST_L0A_LR_RAW"
-    job_release = os.environ['JOB_RELEASE'] # e.g. "gman-dev"
+    # submit mozart jobs to update ES
+    default_job_type = os.environ['DEFAULT_JOB_TYPE'] # e.g. "INGEST_L0A_LR_RAW"
+    default_job_release = os.environ['DEFAULT_JOB_RELEASE'] # e.g. "gman-dev"
+    default_queue = os.environ['DEFAULT_JOB_QUEUE']
+    job_types = {}
+    if 'JOB_TYPES' in os.environ:
+        job_types = json.loads(os.environ['JOB_TYPES'])
+    job_type, job_release, queue = __get_job_type_info(data_file, job_types,
+                                                       default_job_type,
+                                                       default_job_release,
+                                                       default_queue)
     job_spec = "job-%s:%s" % (job_type, job_release)
     job_params = {
         "id": id,
@@ -58,7 +95,6 @@ def lambda_handler(event, context):
         "data_file": data_file,
         "prod_met": md,
     }
-    queue = os.environ['JOB_QUEUE'] # eg.g "factotum-job_worker-large"
     tags = ["data-staged"]
 
     # submit mozart job

--- a/aws/data-staged/lambda_function.py
+++ b/aws/data-staged/lambda_function.py
@@ -26,7 +26,7 @@ def __get_job_type_info(data_file, job_types, default_type, default_release,
     for type in job_types.keys():
         regex = job_types[type]['PATTERN']
         print("Checking if {} matches {}".format(regex, data_file))
-        match = regex.search(data_file)
+        match = re.search(regex, data_file)
         if match:
             return type, job_types[type]['RELEASE'], job_types[type]['QUEUE']
     print("Could not match data file '{}' to a given job type: {}".format(

--- a/aws/data-staged/lambda_function.py
+++ b/aws/data-staged/lambda_function.py
@@ -28,9 +28,14 @@ def __get_job_type_info(data_file, job_types, default_type, default_release,
         print("Checking if {} matches {}".format(regex, data_file))
         match = re.search(regex, data_file)
         if match:
-            return type, job_types[type]['RELEASE'], job_types[type]['QUEUE']
-    print("Could not match data file '{}' to a given job type: {}".format(
-        data_file, job_types.keys()))
+            release = job_types[type]['RELEASE']
+            queue = job_types[type]['QUEUE']
+            print("Data file '{}' matches job type info: "
+                  "type: {}, release: {}, queue: {}".format(
+                data_file, type, release, queue))
+            return type, release, queue
+    print("Could not match data file '{}' to a given job type: {}. "
+          "Using default job type info".format(data_file, job_types.keys()))
     return default_type, default_release, default_queue
 
 


### PR DESCRIPTION
Lambda now supports a new variable named `JOB_TYPES` which contains a mapping of job types to regular expressions. If a data file does not match any of the regexes in the job type mapping, it will use the default setting, which is defined in the current `JOB_TYPE` environment variable. Note that `JOB_TYPES` does not need to be set for the Lambda to work correctly.